### PR TITLE
Fix VpaidAdUnits that throw error on "getAdIcons"

### DIFF
--- a/src/adUnit/VpaidAdUnit.js
+++ b/src/adUnit/VpaidAdUnit.js
@@ -329,8 +329,14 @@ class VpaidAdUnit extends VideoAdUnit {
         this.creativeAd.subscribe(this[_private].handleVpaidEvt.bind(this, creativeEvt), creativeEvt);
       }
 
-      if (this.creativeAd[getAdIcons] && !this.creativeAd[getAdIcons]()) {
-        this.icons = null;
+      if (this.creativeAd[getAdIcons]) {
+        try {
+          if (!this.creativeAd[getAdIcons]()) {
+            this.icons = null;
+          }
+        } catch (error) {
+          this.icons = null;
+        }
       }
 
       handshake(this.creativeAd, '2.0');


### PR DESCRIPTION
Hi guys, at first - huge thanks for maintaining this library, it makes us money! 🙂

Recently I started having lots of creatives that throw when creativeAd[getAdIcons] is being called, but with this patch they work pretty nicely. It would be great if you merged this PR and made a release, otherwise I have to publish and maintain my own fork (which I'd like to avoid 😆).

Please, let me know if I need to reformat the code/commit message/etc. and thanks again for your time and efforts!

